### PR TITLE
Handle key = function_name()

### DIFF
--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -366,6 +366,15 @@ class HclParser(object):
 
     def p_function_0(self, p):
         '''
+        function : IDENTIFIER LEFTPAREN RIGHTPAREN
+        '''
+        if DEBUG:
+            self.print_p(p)
+
+        p[0] = p[1] + p[2] + p[3]
+
+    def p_function_1(self, p):
+        '''
         function : IDENTIFIER LEFTPAREN listitems RIGHTPAREN
                  | IDENTIFIER LEFTPAREN list_of_lists RIGHTPAREN
         '''
@@ -374,7 +383,7 @@ class HclParser(object):
 
         p[0] = p[1] + p[2] + self.flatten(p[3]) + p[4]
 
-    def p_function_1(self, p):
+    def p_function_2(self, p):
         '''
         function : IDENTIFIER LEFTPAREN listitems COMMA RIGHTPAREN
                  | IDENTIFIER LEFTPAREN list_of_lists COMMA RIGHTPAREN
@@ -384,7 +393,7 @@ class HclParser(object):
 
         p[0] = p[1] + p[2] + self.flatten(p[3]) + p[5]
 
-    def p_function_2(self, p):
+    def p_function_3(self, p):
         '''
         function : IDENTIFIER LEFTPAREN list PERIOD PERIOD PERIOD RIGHTPAREN
         '''
@@ -393,7 +402,7 @@ class HclParser(object):
 
         p[0] = p[1] + p[2] + self.flatten(p[3]) + p[4] + p[5] + p[6] + p[7]
 
-    def p_function_3(self, p):
+    def p_function_4(self, p):
         '''
         function : IDENTIFIER LEFTPAREN LEFTBRACKET list_of_lists RIGHTBRACKET PERIOD PERIOD PERIOD RIGHTPAREN
         '''


### PR DESCRIPTION
Fixes parse error on constructs like these which are common in terragrunt configuration files:
```
include {
  path = find_in_parent_folders()
}
```